### PR TITLE
Fix perfdata format for OS load (value=current;warning;critical)

### DIFF
--- a/check_monit.py
+++ b/check_monit.py
@@ -153,7 +153,7 @@ def process_system_load(service):
     avg01 = service.find('%s/avg01'%prefix).text
     avg05 = service.find('%s/avg05'%prefix).text
     avg15 = service.find('%s/avg15'%prefix).text
-    perfdata.append('load=%s;%s;%s'%(avg01,avg05,avg15))
+    perfdata.append('load1=%s load5=%s load15=%s'%(avg01,avg05,avg15))
 
 def process_system_cpu(service):
     prefix = find_existing_prefix(service, ["system/cpu", "cpu"])


### PR DESCRIPTION
This is old Nagios style to return current value with warning and critical. It should not be used for 1 minute, 5 minute and 15 minutes, since those are just different measures and should be returned separately.